### PR TITLE
Fix jetty port to open on 8080

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,8 @@
         <version>2.11.2</version>
         <configuration>
           <reportVersion>${allure.version}</reportVersion>
-        </configuration>
+          <servePort>8080</servePort>
+      </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Set up Allure report to be served on port **8080** as mentioned in [README file](https://github.com/selenide-examples/selenide-allure-junit/blob/637fd06fcfb2e3a5f7904e40250f53a632c02255/README.md).